### PR TITLE
/live if there is only one presentation, redirect there

### DIFF
--- a/routes/user/handlers.js
+++ b/routes/user/handlers.js
@@ -138,6 +138,10 @@ function getLivePresentations(req, res) {
                       + '/?role=viewer&view=presentation';
       })
 
+      if (slideshows.length == 1) {
+        return res.redirect(slideshows[0].liveUrl);
+      }
+
       res.render('userLive', {
       livePresentations: slideshows,
       username: req.routeOwner.username,


### PR DESCRIPTION
When there is only one presentation it's a better UX to redirect immediately there